### PR TITLE
Fix werkzeug version and specified the all others packages version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-Flask
-flask-restx
-requests
+Flask==2.1.3
+flask-restx==0.5.1
+requests==2.28.1
+werkzeug==2.1.2


### PR DESCRIPTION
The container would run fail due to the werkzug version.
```
Traceback (most recent call last):
  File "/app/app.py", line 2, in <module>
    from flask_restx import Api, Resource
  File "/usr/local/lib/python3.9/site-packages/flask_restx/__init__.py", line 5, in <module>
    from .api import Api  # noqa
  File "/usr/local/lib/python3.9/site-packages/flask_restx/api.py", line 50, in <module>
    from .swagger import Swagger
  File "/usr/local/lib/python3.9/site-packages/flask_restx/swagger.py", line 18, in <module>
    from werkzeug.routing import parse_rule
ImportError: cannot import name 'parse_rule' from 'werkzeug.routing' (/usr/local/lib/python3.9/site-packages/werkzeug/routing/__init__.py)
```